### PR TITLE
Lrrecords branding

### DIFF
--- a/lr-brand/README_BRANDING.md
+++ b/lr-brand/README_BRANDING.md
@@ -1,0 +1,30 @@
+LRRecords branding wrapper for GrooveScribe
+
+What this folder does
+- lr-brand/index.html — a branded wrapper page that embeds the GrooveScribe app using an iframe.
+- lr-brand/css/lr-brand.css — styling and color variables based on the provided palette.
+- lr-brand/assets/lrrecords-logo.png — logo (replace with your supplied PNG/SVG if preferred).
+
+How to use / deploy
+Option A — Host on the same site (recommended)
+1. Copy the lr-brand folder into your site under /drumming-tutor/ so the wrapper will sit at:
+   /drumming-tutor/index.html
+2. Ensure the iframe src in lr-brand/index.html points to the app root you want:
+   - If you left the app at repo root (index.html), iframe src="../index.html" works when lr-brand is inside a subfolder.
+   - If you copy the whole app into lr-brand/app/, set iframe src="./app/index.html".
+3. Upload the folder to your host. Visit https://lrrecords.com.au/drumming-tutor to verify.
+
+Option B — Deploy wrapper as a static folder (Netlify/GitHub Pages/Vercel)
+1. Deploy lr-brand folder as the root of a static site and use the published URL in EasyFunnels embed widget (iframe).
+
+Embed on EasyFunnels page
+- Use the EasyFunnels "embed code" widget (HTML) and paste this minimal iframe:
+
+  <iframe src="https://lrrecords.com.au/drumming-tutor/" style="width:100%;height:900px;border:0;" title="LRRecords Drummer"></iframe>
+
+Customization notes
+- Replace lr-brand/assets/lrrecords-logo.png with your preferred PNG/SVG for exact branding.
+- If you prefer removing the iframe and applying branding directly inside the GrooveScribe pages, I can update the app's index.html and CSS in-place (replace logos, add the CSS variables to the app's stylesheet, etc.). This requires modifying files across the repo.
+
+Next step
+- I have added the wrapper index.html to the branch. I will now add the CSS and README and include the uploaded PNG into lr-brand/assets/lrrecords-logo.png and open the PR.

--- a/lr-brand/assets/lrrecords-logo.png
+++ b/lr-brand/assets/lrrecords-logo.png
@@ -1,0 +1,1 @@
+<binary content for lrrecords-logo.png>

--- a/lr-brand/css/lr-brand.css
+++ b/lr-brand/css/lr-brand.css
@@ -1,0 +1,42 @@
+:root{
+  /* Brand palette provided by the user */
+  --eastern-blue: #1e81b0;
+  --green-white: #eeeee4;
+  --burnt-sienna: #e28743;
+  --tacao: #eab676;
+  --glacier: #76b5c5;
+  --eternity: #21130d;
+  --burnt-umber: #873e23;
+  --powder-blue: #abdbe3;
+  --catalina-blue: #063970;
+  --chathams-blue: #154c79;
+
+  --lr-bg: var(--green-white);
+  --lr-text: var(--eternity);
+  --lr-accent: var(--burnt-sienna);
+  --lr-primary: var(--eastern-blue);
+
+  --lr-max-width: 1200px;
+}
+
+*{box-sizing:border-box}
+html,body{height:100%;margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial;color:var(--lr-text);background:var(--lr-bg);} 
+.lr-header{background:linear-gradient(90deg,var(--lr-primary),var(--chathams-blue));color:white;padding:10px 0;box-shadow:0 2px 8px rgba(0,0,0,0.08);position:sticky;top:0;z-index:30}
+.lr-header-inner{max-width:var(--lr-max-width);margin:0 auto;display:flex;align-items:center;gap:16px;padding:8px 16px;}
+.lr-logo{height:56px;width:auto}
+.lr-title h1{margin:0;font-size:1.15rem;letter-spacing:0.3px}
+.lr-sub{margin:0;font-size:0.85rem;opacity:0.95}
+.lr-actions{margin-left:auto}
+.btn{display:inline-block;padding:8px 12px;background:rgba(255,255,255,0.12);color:white;border-radius:6px;text-decoration:none;font-weight:700}
+.btn:hover{background:rgba(255,255,255,0.18)}
+
+.lr-main{display:block;max-width:100%;padding:18px;background:transparent}
+#groovescribe-frame{width:100%;border-radius:8px;border:1px solid rgba(0,0,0,0.08);display:block;min-height:520px;background:white;box-shadow:0 8px 30px rgba(0,0,0,0.08)}
+.lr-footer{height:46px;display:flex;align-items:center;justify-content:center;color:var(--lr-text);font-size:0.9rem;padding:8px;background:transparent;margin-top:12px}
+
+@media (max-width:720px){
+  .lr-logo{height:48px}
+  .lr-header-inner{padding:10px}
+  .lr-title h1{font-size:1rem}
+  #groovescribe-frame{min-height:520px}
+}

--- a/lr-brand/index.html
+++ b/lr-brand/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>LRRecords Drummer — GrooveScribe</title>
+  <link rel="stylesheet" href="css/lr-brand.css" />
+  <meta name="robots" content="noindex,nofollow" />
+</head>
+<body>
+  <header class="lr-header">
+    <div class="lr-header-inner">
+      <img class="lr-logo" src="assets/lrrecords-logo.svg" alt="LRRecords Drummer logo" />
+      <div class="lr-title">
+        <h1>LRRecords Drummer</h1>
+        <p class="lr-sub">Sheet music creation, groove practice & tutor tools</p>
+      </div>
+      <nav class="lr-actions">
+        <a class="btn" href="https://lrrecords.com.au/drumming-tutor" target="_blank" rel="noopener">Course page</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="lr-main">
+    <!--
+      By default this wrapper loads the GrooveScribe app from the repo root.
+      If you copy the original app into lr-brand/app/ then set src="./app/index.html"
+      If you want the branded page to embed the site at the site root, use src="../index.html"
+    -->
+    <iframe id="groovescribe-frame" src="../index.html" title="GrooveScribe app" frameborder="0" allowfullscreen></iframe>
+  </main>
+
+  <footer class="lr-footer">
+    <small>© LRRecords — drumming tutor resources</small>
+  </footer>
+
+  <script>
+    // Keep the iframe tall enough to fill viewport minus header/footer.
+    function resizeIframe() {
+      var header = document.querySelector('.lr-header');
+      var footer = document.querySelector('.lr-footer');
+      var frame = document.getElementById('groovescribe-frame');
+      var vh = window.innerHeight;
+      var used = (header ? header.offsetHeight : 0) + (footer ? footer.offsetHeight : 0);
+      frame.style.height = Math.max(400, (vh - used)) + 'px';
+    }
+    window.addEventListener('resize', resizeIframe);
+    window.addEventListener('load', resizeIframe);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Title
Add LRRecords-branded wrapper for GrooveScribe (lr-brand)

Body
Adds a new folder `lr-brand` with a branded wrapper page that embeds the GrooveScribe app in an iframe.

Files added:
- lr-brand/index.html — branded wrapper page
- lr-brand/css/lr-brand.css — brand stylesheet (uses the palette provided)
- lr-brand/assets/lrrecords-logo.png — supplied logo
- lr-brand/README_BRANDING.md — install & embed instructions

Deployment notes:
- Option A (recommended): place `lr-brand` at `/drumming-tutor/` on your site and ensure the iframe `src` in `lr-brand/index.html` points to the correct app entry:
  - If the app remains at the repo root, use iframe `src="../index.html"`.
  - If you copy the app into `lr-brand/app/`, use iframe `src="./app/index.html"`.
- Option B: deploy `lr-brand` as a static site (Netlify/GitHub Pages/Vercel) and embed it in EasyFunnels via iframe.

How to swap the logo / change iframe paths:
- Replace `lr-brand/assets/lrrecords-logo.png` with a different PNG or an SVG (same filename) and commit.
- Edit the iframe `src` line in `lr-brand/index.html` to point at the desired app path.

Notes:
- Hosting the wrapper and app on the same origin is recommended to avoid CORS/localStorage issues.
- If you prefer, I can instead apply branding directly inside the GrooveScribe app (replace logos & CSS). That would change the app pages in-place — I can prepare a PR for that too if you want.

Embed snippet for EasyFunnels (copy into the embed widget)
- If hosting wrapper at https://lrrecords.com.au/drumming-tutor/:
  <iframe src="/drumming-tutor/" style="width:100%;height:900px;border:0;" title="LRRecords Drummer"></iframe>
- If using a different published URL, replace src with that URL.